### PR TITLE
add --no-dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Manage global qontract-development-cli configuration.
 | profiles_dir                | Directory to store profile files      | User config directory / profiles     |
 | worktrees_dir               | Directory to store git repo worktrees | User cache directory / worktrees     |
 
-
 ## Environments
 
 An environment specifies app-interface instance settings, e.g., **dev** vs. **prod** config and path to the actual app-interface instance.
@@ -131,6 +130,16 @@ A profile specifies all settings to run a qontract-reconcile integration (e.g., 
 * **run**: Run a profile.
 * **show**: Display profile.
 
+### --no-dry-run
+
+By default `qd` runs integrations in `dry-run` mode if not explicitly specified differently in the profile config.
+There is also a `--no-dry-run` flag which lets you disable `dry-run` mode from command line.
+
+```
+$ qd profile run dev my-integration --no-dry-run
+```
+
+The command line flag takes precedence over any configuration you might have in the profile settings.
 
 #### Settings
 

--- a/qontract_development_cli/commands/profile.py
+++ b/qontract_development_cli/commands/profile.py
@@ -210,6 +210,10 @@ def run(
         False,
         help="Do not run 'make bundle' before starting the integration",
     ),
+    no_dry_run: bool = typer.Option(
+        False,
+        help="Disable dry-run mode",
+    ),
 ):
     """Run a profile."""
     env = Env(name=env_name)
@@ -217,6 +221,9 @@ def run(
     profile.settings.app_interface_path = (
         profile.settings.app_interface_path or env.settings.app_interface_path
     )
+    if no_dry_run:
+        # if --no-dry-run is set on command line, then it takes prio over all other dry-run settings
+        profile.settings.dry_run = False
     # prepare worktrees
     fetch_pull_requests(profile, config.worktrees_dir)
 


### PR DESCRIPTION
```
qd profile run dev my-integration --no-dry-run
```

The profile `my-integration` is configured to run in dry-run mode. However, I would like to quickly change that just for a single run. A flag that takes precedence over config files is easier to use in this scenario.

Wdyt?