### PR TITLE
fix(docker-compose): fix qontract-reconcile restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.11.1 (2023-08-01)
+
+### Bug Fixes
+
+- **docker-compose**: fix qontract-reconcile restart
+- **compose-file**: fix empty qontract-reconcile.links list when no other container wants to be started (#14)
+- **release**: local release and push to pypi via jenkins job (#12)
+- **release**: fix release process (#11)
+
+### Features
+
+- **docker-compose**: run docker-compose logs in endless loop (#16)
+- move project to app-sre organization
+
+## v0 (2022-10-24)
+
+### Bug Fixes
+
+- consitent logging
+
+### Features
+
+- **profile run**: monitor file changes and restart containers
+
 ## v0.12.0 (2023-05-26)
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ ignore_missing_imports = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.11.0"
+version = "0.11.1"
 version_files = ["pyproject.toml:version"]
 update_changelog_on_bump = true
 major_version_zero = true

--- a/qontract_development_cli/commands/profile.py
+++ b/qontract_development_cli/commands/profile.py
@@ -27,7 +27,6 @@ from ..models import (
 from ..shell import (
     compose_down,
     compose_log_tail,
-    compose_restart,
     compose_stop_project,
     compose_up,
     container_restart,

--- a/qontract_development_cli/commands/profile.py
+++ b/qontract_development_cli/commands/profile.py
@@ -30,6 +30,7 @@ from ..shell import (
     compose_restart,
     compose_stop_project,
     compose_up,
+    container_restart,
     fetch_pull_requests,
     make_bundle,
     make_bundle_and_restart_server,
@@ -271,8 +272,10 @@ def run(
             watch_files(
                 path=profile.settings.qontract_reconcile_path.expanduser().absolute(),
                 extensions=qontract_reconcile_monitor_file_extensions.split(" "),
-                action=compose_restart,
-                action_args=(compose_file, "qontract-reconcile"),
+                action=container_restart,
+                action_args=(
+                    f"qontract-reconcile-{ profile.settings.integration_name }",
+                ),
             ),
         )
     if qontract_schemas_monitor_file_changes:
@@ -310,7 +313,9 @@ def run(
             key = "q"
 
         if key.lower() == "r":
-            compose_restart(compose_file, "qontract-reconcile")
+            container_restart(
+                f"qontract-reconcile-{ profile.settings.integration_name }"
+            )
         elif key.lower() == "b":
             if not env.settings.run_qontract_server:
                 console.print(

--- a/qontract_development_cli/shell.py
+++ b/qontract_development_cli/shell.py
@@ -52,6 +52,12 @@ def compose_restart(compose_file: Path, container: str) -> None:
     subprocess.run(compose_cmd)
 
 
+def container_restart(container: str) -> None:
+    log.info(f"Restarting {container} container")
+    compose_cmd = ["docker", "restart", container]
+    subprocess.run(compose_cmd)
+
+
 def compose_down(compose_file: Path) -> None:
     log.info("Stopping all containers")
     compose_cmd = _docker_compose_bin + ["-f", str(compose_file), "down"]


### PR DESCRIPTION
`docker-compose restart` complains

```
service qontract-server is required by qontract-reconcile but is disabled. Can be enabled by profiles []
```

use `docker restart` instead.