### PR TITLE
**:sparkles: profile run: --skip-initial-make-bundle profile settings variable**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.14.2 (2024-03-14)
+
+### Features
+
+- **profile run**: support `--skip-initial-make-bundle` option via profile settings
+
 ## v0.14.1 (2024-02-13)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The command line flag takes precedence over any configuration you might have in 
 | sleep_duration_secs            | If not *run_once*, sleep duration until integration runs again                                                                                                               | `10`                                                         |
 | localstack                     | Run localstack container and set AWS related environment variables                                                                                                           | `false`                                                      |
 | localstack_compose_file        | Path to your Localstack docker-compose file                                                                                                                                  | `qontract_server_path` / `dev/localstack/docker-compose.yml` |
+| skip_initial_make_bundle       | Skip initial make bundle step                                                                                                                                                | `false`                                                      |
 
 > :point_right: **Bold keys** are mandatory or should be customized.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qontract-development-cli"
-version = "0.14.1"
+version = "0.14.2"
 description = "Helper tool for qontract-reconcile development"
 authors = ["Christian Assing <cassing@redhat.com>"]
 license = "MIT"

--- a/qontract_development_cli/commands/profile.py
+++ b/qontract_development_cli/commands/profile.py
@@ -224,6 +224,9 @@ def run(  # noqa: PLR0912, PLR0917, PLR0913, PLR0915
     if no_dry_run:
         # if --no-dry-run is set on command line, then it takes prio over all other dry-run settings
         profile.settings.dry_run = False
+    skip_initial_make_bundle = (
+        skip_initial_make_bundle or profile.settings.skip_initial_make_bundle
+    )
     # prepare worktrees
     fetch_pull_requests(profile, config.worktrees_dir)
 

--- a/qontract_development_cli/models.py
+++ b/qontract_development_cli/models.py
@@ -56,6 +56,7 @@ class ProfileSettings(BaseModel):
     extra_hosts: list[str] = []
     localstack: bool = False
     localstack_compose_file: Path | None
+    skip_initial_make_bundle: bool = False
 
     @validator("localstack_compose_file", always=True)
     def default_localstack_compose_file(cls, v: Path | None, values: dict) -> Path:


### PR DESCRIPTION
New profile settings variable `skip_initial_make_bundle` to enable `--skip-initial-make-bundle` as default

