### PR TITLE
feat: add OPA sidecar support for qontract-api authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.19.0 (2026-06-09)
+
+### Features
+
+* Add OPA (Open Policy Agent) sidecar support for qontract-api authorization
+* New `run_opa` environment toggle and `opa_build_image` profile setting
+* OPA image built from `qontract-reconcile/opa/Dockerfile` with Rego policy tests
+* Dev policy data mounted separately from prod image (`opa/dev/`)
+* OPA decision logs enabled via `dev/config.yaml`
+
 ## v0.18.1 (2026-06-03)
 
 ### Bugfixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qontract-development-cli"
-version = "0.18.1"
+version = "0.19.0"
 description = "Helper tool for qontract-reconcile development"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT" }

--- a/qontract_development_cli/commands/profile.py
+++ b/qontract_development_cli/commands/profile.py
@@ -265,6 +265,7 @@ def run(  # noqa: C901, PLR0912, PLR0913, PLR0915
     compose_template_files = profile.settings.compose_template_files(
         api=env.settings.run_qontract_api,
         cache=env.settings.run_cache,
+        opa=env.settings.run_opa,
         reconcile=env.settings.run_qontract_reconcile,
         server=env.settings.run_qontract_server,
         subscriber=env.settings.run_qontract_api_subscriber,

--- a/qontract_development_cli/models.py
+++ b/qontract_development_cli/models.py
@@ -21,6 +21,7 @@ class EnvSettings(BaseModel):
     run_qontract_api_subscriber: bool = False
     run_qontract_api_worker: bool = False
     run_cache: bool = False
+    run_opa: bool = False
     run_qontract_reconcile: bool = True
     run_qontract_server: bool = True
     run_vault: bool = False
@@ -103,6 +104,12 @@ class ProfileSettings(BaseModel):
     localstack: bool = False
     localstack_compose_file: Path | None
 
+    # opa
+    opa_build_image: bool = True
+    opa_image: str = "openpolicyagent/opa:latest"
+    opa_container_platform: str | None = None
+    opa_compose_file: str = "opa.yml.j2"
+
     # vault
     vault_image: str = "vault:1.5.4"
     vault_container_platform: str | None = None
@@ -120,11 +127,16 @@ class ProfileSettings(BaseModel):
     def qontract_api_path(self) -> Path | None:
         return self.qontract_reconcile_path / "qontract_api"
 
+    @property
+    def opa_path(self) -> Path | None:
+        return self.qontract_reconcile_path / "opa"
+
     def compose_template_files(  # noqa: PLR0913
         self,
         *,
         api: bool,
         cache: bool,
+        opa: bool,
         reconcile: bool,
         server: bool,
         subscriber: bool,
@@ -135,6 +147,7 @@ class ProfileSettings(BaseModel):
         files += [self.qontract_api_subscriber_compose_file] if subscriber else []
         files += [self.qontract_api_worker_compose_file] if worker else []
         files += [self.cache_compose_file] if cache else []
+        files += [self.opa_compose_file] if opa else []
         files += [self.qontract_reconcile_compose_file] if reconcile else []
         files += [self.qontract_server_compose_file] if server else []
         files += [self.vault_compose_file] if vault else []

--- a/qontract_development_cli/templates/api.yml.j2
+++ b/qontract_development_cli/templates/api.yml.j2
@@ -19,6 +19,11 @@ services:
     environment:
     - QAPI_START_MODE=api
     - QAPI_CACHE_BROKER_URL=redis://cache:6379/0
+    {% if env.settings.run_opa %}
+    - QAPI_OPA__HOST=http://opa:8181
+    {% else %}
+    - QAPI_OPA__ENABLED=false
+    {% endif %}
     # Enable debugpy
     - DEBUGGER_ENABLED={% if profile.settings.debugger %}true{% else %}false{% endif %}
     # Hot reload for development

--- a/qontract_development_cli/templates/compose.override.yml.j2
+++ b/qontract_development_cli/templates/compose.override.yml.j2
@@ -8,18 +8,36 @@ services:
 {% endif %}
 
 
+{% if env.settings.run_opa %}
+  opa:
+    networks:
+    - qontract-development
+{% endif %}
+
+
 {% if env.settings.run_qontract_api %}
   qontract-api:
     networks:
     - qontract-development
 
-    {% if env.settings.run_cache %}
+    {% if env.settings.run_cache or env.settings.run_opa %}
     depends_on:
+      {% if env.settings.run_cache %}
       cache:
         condition: service_healthy
+      {% endif %}
+      {% if env.settings.run_opa %}
+      opa:
+        condition: service_started
+      {% endif %}
 
     links:
+    {% if env.settings.run_cache %}
     - cache
+    {% endif %}
+    {% if env.settings.run_opa %}
+    - opa
+    {% endif %}
     {% endif %}
 {% endif %}
 

--- a/qontract_development_cli/templates/opa.yml.j2
+++ b/qontract_development_cli/templates/opa.yml.j2
@@ -1,0 +1,37 @@
+services:
+  # OPA (Open Policy Agent) sidecar for qontract-api authorization
+  opa:
+    container_name: opa
+    platform: {{ profile.settings.opa_container_platform or env.settings.container_platform }}
+    {% if profile.settings.opa_build_image %}
+    build:
+      context: {{ profile.settings.qontract_reconcile_path.expanduser().absolute() }}
+      dockerfile: {{ profile.settings.opa_path.expanduser().absolute() }}/Dockerfile
+      target: prod
+    {% else %}
+    image: {{ profile.settings.opa_image }}
+    {% endif %}
+
+    entrypoint: ["/opa"]
+    command:
+    - run
+    - --server
+    - --addr=0.0.0.0:8181
+    - --config-file=/config/config.yaml
+    - --log-level=info
+    - --disable-telemetry
+    - --watch
+    - /authz
+    - /data
+
+    ports:
+    - 8181:8181
+
+    # /authz is baked into the image (Rego policies)
+    # /data is mounted from dev/ (dev policy data, NOT in the prod image)
+    # --watch uses fsnotify: works on Linux, not on macOS/Colima.
+    # On macOS, run: docker restart opa
+    volumes:
+    - {{ profile.settings.opa_path.expanduser().absolute() }}/authz:/authz:z
+    - {{ profile.settings.opa_path.expanduser().absolute() }}/dev:/data:z
+    - {{ profile.settings.opa_path.expanduser().absolute() }}/dev/config.yaml:/config/config.yaml:z

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ wheels = [
 
 [[package]]
 name = "qontract-development-cli"
-version = "0.18.1"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

- Add OPA (Open Policy Agent) as an optional service in the dev stack for parameter-level authorization of qontract-api requests
- OPA image built from `qontract-reconcile/opa/Dockerfile` (Rego policies baked in, dev policy data mounted separately)
- Decision logs enabled for structured authZ audit trail

## Changes

- `run_opa` env toggle + `opa_build_image`/`opa_image` profile settings
- New `opa.yml.j2` compose template with OPA config, `--watch`, and volume mounts
- `compose.override.yml.j2`: OPA networking + `depends_on` for qontract-api
- `api.yml.j2`: `QAPI_OPA__HOST`/`QAPI_OPA__ENABLED` env vars
- Version bump to 0.19.0

## Related

- Design doc: https://github.com/openshift-online/platform-engineering-enhancements/pull/51
- [APPSRE-14303](https://issues.redhat.com/browse/APPSRE-14303)

## Test plan

- [ ] Set `run_opa: true` + `run_qontract_api: true` in env
- [ ] `qd profile run` starts OPA sidecar alongside qontract-api
- [ ] OPA loads Rego policies + dev roles from mounted volumes
- [ ] Decision logs appear on OPA stdout
- [ ] qontract-api connects to OPA for authorization