### PR TITLE
fix: escape reconcile.yml env var values to prevent invalid YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.19.1 (2026-07-20)
+
+### Bugfixes
+
+* Fix invalid `reconcile.yml` YAML when `integration_extra_args`, `command_extra_args`, or `additional_environment` values contain YAML-special characters (e.g. JSON passed to `--keycloak-instances`)
+
 ## v0.19.0 (2026-06-09)
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN uv lock --locked
 COPY README.md Makefile ./
 # the source code
 COPY qontract_development_cli ./qontract_development_cli
+COPY tests ./tests
 
 # Install dependencies
 RUN uv sync --frozen

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 	$(UV_RUN) ruff check --no-fix
 	$(UV_RUN) ruff format --check
 	$(UV_RUN) mypy
+	$(UV_RUN) pytest
 .PHONY: test
 
 # do not print pypi commands to avoid the token leaking to the logs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qontract-development-cli"
-version = "0.19.0"
+version = "0.19.1"
 description = "Helper tool for qontract-reconcile development"
 authors = [{ name = "Christian Assing", email = "cassing@redhat.com" }]
 license = { text = "MIT" }
@@ -22,9 +22,13 @@ dependencies = [
 dev = [
     # dev dependencies
     "mypy ~=2.0",
+    "pytest ~=8.3",
     "ruff ~=0.7",
     "types-pyyaml ~=6.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [project.urls]
 homepage = "http://github.com/chassing/qontract-development-cli"

--- a/qontract_development_cli/templates/reconcile.yml.j2
+++ b/qontract_development_cli/templates/reconcile.yml.j2
@@ -28,9 +28,9 @@ services:
 
     environment:
     - COMMAND={{ profile.settings.command }}
-    - COMMAND_EXTRA_ARGS={{ profile.settings.command_extra_args }}
+    - {{ ("COMMAND_EXTRA_ARGS=" ~ profile.settings.command_extra_args) | tojson }}
     - INTEGRATION_NAME={{ profile.settings.integration_name }}
-    - INTEGRATION_EXTRA_ARGS={{ profile.settings.integration_extra_args }}
+    - {{ ("INTEGRATION_EXTRA_ARGS=" ~ profile.settings.integration_extra_args) | tojson }}
     - DRY_RUN={% if profile.settings.dry_run %}--dry-run{% else %}--no-dry-run{% endif +%}
     - SLEEP_DURATION_SECS={{ profile.settings.sleep_duration_secs }}
     - DEBUGGER={{ profile.settings.debugger }}
@@ -44,7 +44,7 @@ services:
     - LOG_LEVEL={{ profile.settings.log_level.upper() }}
 
     {% for key, value in profile.settings.additional_environment.items() %}
-    - {{ key }}={{ value }}
+    - {{ (key ~ "=" ~ value) | tojson }}
     {% endfor %}
 
     volumes:

--- a/tests/test_reconcile_template.py
+++ b/tests/test_reconcile_template.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from qontract_development_cli.models import EnvSettings, ProfileSettings
+from qontract_development_cli.templates import template
+
+
+def render_reconcile_yml(
+    *,
+    integration_extra_args: str = "",
+    command_extra_args: str = "",
+    additional_environment: dict[str, str] | None = None,
+) -> str:
+    profile = SimpleNamespace(
+        settings=ProfileSettings(
+            integration_name="test-integration",
+            integration_extra_args=integration_extra_args,
+            command_extra_args=command_extra_args,
+            additional_environment=additional_environment or {},
+            localstack_compose_file=None,
+        )
+    )
+    env = SimpleNamespace(settings=EnvSettings())
+    return template("reconcile.yml.j2", profile=profile, env=env)
+
+
+@pytest.mark.parametrize(
+    "integration_extra_args",
+    [
+        # colon-space sequences are YAML mapping indicators when unquoted
+        '--keycloak-instances \'{"url": "https://example.com", "secret": {"path": "x"}}\'',
+        "--foo bar # not a comment",
+    ],
+)
+def test_integration_extra_args_with_special_chars_produces_valid_yaml(
+    integration_extra_args: str,
+) -> None:
+    rendered = render_reconcile_yml(integration_extra_args=integration_extra_args)
+
+    compose = yaml.safe_load(rendered)
+
+    env_list = compose["services"]["qontract-reconcile"]["environment"]
+    assert f"INTEGRATION_EXTRA_ARGS={integration_extra_args}" in env_list
+
+
+def test_command_extra_args_with_colon_produces_valid_yaml() -> None:
+    rendered = render_reconcile_yml(command_extra_args='--config \'{"a": "b"}\'')
+
+    compose = yaml.safe_load(rendered)
+
+    env_list = compose["services"]["qontract-reconcile"]["environment"]
+    assert 'COMMAND_EXTRA_ARGS=--config \'{"a": "b"}\'' in env_list
+
+
+def test_additional_environment_with_colon_produces_valid_yaml() -> None:
+    rendered = render_reconcile_yml(
+        additional_environment={"FOO": '{"a": "b"}'},
+    )
+
+    compose = yaml.safe_load(rendered)
+
+    env_list = compose["services"]["qontract-reconcile"]["environment"]
+    assert 'FOO={"a": "b"}' in env_list

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -249,12 +258,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -337,6 +364,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -373,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "qontract-development-cli"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
@@ -390,6 +433,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -410,6 +454,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = "~=2.0" },
+    { name = "pytest", specifier = "~=8.3" },
     { name = "ruff", specifier = "~=0.7" },
     { name = "types-pyyaml", specifier = "~=6.0" },
 ]


### PR DESCRIPTION
## Summary
- `reconcile.yml.j2` interpolated `integration_extra_args`, `command_extra_args`, and `additional_environment` values into the compose YAML unquoted. A JSON value passed via `--keycloak-instances` (containing `": "`) produced invalid YAML: `mapping values are not allowed in this context`.
- The Jinja `Environment` also runs with `autoescape=True`, which was HTML-entity-encoding quotes (`"` → `&#34;`, `'` → `&#39;`) before the value even reached the YAML parser, corrupting the value further.
- Fixed by rendering those three env var entries with the `tojson` filter, which safely JSON/YAML-escapes the whole `KEY=value` pair and returns Jinja `Markup` (so autoescape doesn't double-encode it). Verified the original string round-trips exactly through YAML parsing.
- Added `tests/test_reconcile_template.py` (new pytest setup for the repo) reproducing the bug first, then confirming the fix.
- Bumped to v0.19.1 and updated CHANGELOG.md.

## Test plan
- [x] New test reproduces the original bug (fails without the fix)
- [x] New test passes with the fix, and the parsed env var value matches the original raw string exactly
- [x] Verified against the real-world profile that triggered this (`--keycloak-instances` JSON) — rendered `reconcile.yml` now parses cleanly
- [x] `make test` (ruff check, ruff format --check, mypy, pytest) passes